### PR TITLE
LoongArch: Add loongarch64 cpu for minidump_dump

### DIFF
--- a/src/processor/minidump.cc
+++ b/src/processor/minidump.cc
@@ -4029,6 +4029,10 @@ string MinidumpSystemInfo::GetCPU() {
       cpu = "riscv64";
       break;
 
+    case MD_CPU_ARCHITECTURE_LOONGARCH64:
+      cpu = "loongarch64";
+      break;
+
     default:
       BPLOG(ERROR) << "MinidumpSystemInfo unknown CPU for architecture " <<
                       HexString(system_info_.processor_architecture);


### PR DESCRIPTION
fix 'MinidumpSystemInfo unknown CPU for architecture' error.